### PR TITLE
Added WaiverSigned Events & Listeners

### DIFF
--- a/src/Events/WaiverSigned.php
+++ b/src/Events/WaiverSigned.php
@@ -2,15 +2,17 @@
 
 namespace Tipoff\Waivers\Events;
 
-use Tipoff\Waivers\Models\Signature;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Broadcasting\PrivateChannel;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Tipoff\Waivers\Models\Signature;
 
 class WaiverSigned
 {
-    use Dispatchable, InteractsWithSockets, SerializesModels;
+    use Dispatchable;
+    use InteractsWithSockets;
+    use SerializesModels;
 
     public $signature;
 

--- a/src/Events/WaiverSigned.php
+++ b/src/Events/WaiverSigned.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tipoff\Waivers\Events;
+
+use Tipoff\Waivers\Models\Signature;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class WaiverSigned
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public $signature;
+
+    /**
+     * Create a new event instance.
+     *
+     * @param Signature $signature
+     */
+    public function __construct(Signature $signature)
+    {
+        $this->signature = $signature;
+    }
+
+    /**
+     * Get the channels the event should broadcast on.
+     *
+     * @return \Illuminate\Broadcasting\Channel|array
+     */
+    public function broadcastOn()
+    {
+        return new PrivateChannel('channel-name');
+    }
+}

--- a/src/Listeners/CreateParticipant.php
+++ b/src/Listeners/CreateParticipant.php
@@ -2,8 +2,8 @@
 
 namespace Tipoff\Waivers\Listeners;
 
-use Tipoff\Waivers\Events\WaiverSigned;
 use Carbon\Carbon;
+use Tipoff\Waivers\Events\WaiverSigned;
 
 class CreateParticipant
 {
@@ -41,9 +41,9 @@ class CreateParticipant
         $existing = app('feedback')->withTrashed()->where('participant_id', $participant->id)->where('location_id', $signature->room->location->id)->where('date', $date)->first();
         if (empty($existing)) {
             app('feedback')->create([
-                'participant_id'    => $participant->id,
-                'location_id'       => $signature->room->location->id,
-                'date'              => $date
+                'participant_id' => $participant->id,
+                'location_id' => $signature->room->location->id,
+                'date' => $date,
             ]);
         }
     }

--- a/src/Listeners/CreateParticipant.php
+++ b/src/Listeners/CreateParticipant.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tipoff\Waivers\Listeners;
+
+use Tipoff\Waivers\Events\WaiverSigned;
+use Carbon\Carbon;
+
+class CreateParticipant
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  WaiverSigned  $event
+     * @return void
+     */
+    public function handle(WaiverSigned $event)
+    {
+        $signature = $event->signature;
+
+        $participant = app('participant')->withTrashed()->firstOrNew(['email' => $signature->email]);
+        $participant->name = $signature->name;
+        $participant->name_last = $signature->name_last;
+        $participant->dob = $signature->dob;
+        $participant->save();
+
+        $signature->participant_id = $participant->id;
+        $signature->save();
+
+        $created = new Carbon($signature->created_at, 'UTC');
+        $date = $created->setTimezone($signature->room->location->php_tz)->format('Y-m-d');
+        $existing = app('feedback')->withTrashed()->where('participant_id', $participant->id)->where('location_id', $signature->room->location->id)->where('date', $date)->first();
+        if (empty($existing)) {
+            app('feedback')->create([
+                'participant_id'    => $participant->id,
+                'location_id'       => $signature->room->location->id,
+                'date'              => $date
+            ]);
+        }
+    }
+}

--- a/src/Listeners/SendWaiverConfirmation.php
+++ b/src/Listeners/SendWaiverConfirmation.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tipoff\Waivers\Listeners;
+
+use Tipoff\Waivers\Events\WaiverSigned;
+
+class SendWaiverConfirmation
+{
+    /**
+     * Create the event listener.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Handle the event.
+     *
+     * @param  WaiverSigned  $event
+     * @return void
+     */
+    public function handle(WaiverSigned $event)
+    {
+        // $signature = $event->signature;
+
+        // Mail::send(new WaiverConfirmation($signature));
+
+        // $signature->emailed_at = Carbon::now();
+        // $signature->save();
+    }
+}

--- a/src/WaiversServiceProvider.php
+++ b/src/WaiversServiceProvider.php
@@ -23,8 +23,8 @@ class WaiversServiceProvider extends TipoffServiceProvider
             ->hasEvents([
                 WaiverSigned::class => [
                     SendWaiverConfirmation::class,
-                    CreateParticipant::class
-                ]
+                    CreateParticipant::class,
+                ],
             ])
             ->name('waivers')
             ->hasConfigFile();

--- a/src/WaiversServiceProvider.php
+++ b/src/WaiversServiceProvider.php
@@ -6,6 +6,9 @@ namespace Tipoff\Waivers;
 
 use Tipoff\Support\TipoffPackage;
 use Tipoff\Support\TipoffServiceProvider;
+use Tipoff\Waivers\Events\WaiverSigned;
+use Tipoff\Waivers\Listeners\CreateParticipant;
+use Tipoff\Waivers\Listeners\SendWaiverConfirmation;
 use Tipoff\Waivers\Models\Signature;
 use Tipoff\Waivers\Policies\SignaturePolicy;
 
@@ -16,6 +19,12 @@ class WaiversServiceProvider extends TipoffServiceProvider
         $package
             ->hasPolicies([
                 Signature::class => SignaturePolicy::class,
+            ])
+            ->hasEvents([
+                WaiverSigned::class => [
+                    SendWaiverConfirmation::class,
+                    CreateParticipant::class
+                ]
             ])
             ->name('waivers')
             ->hasConfigFile();

--- a/tests/Unit/Events/WaiverSignedTest.php
+++ b/tests/Unit/Events/WaiverSignedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Waivers\Tests\Unit\Events;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tipoff\Waivers\Events\WaiverSigned;
+use Tipoff\Waivers\Models\Signature;
+use Tipoff\Waivers\Tests\TestCase;
+use Illuminate\Support\Facades\Event;
+
+class WaiverSignedTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function waiver_event_fired()
+    {
+        Event::fake();
+
+        $signature = Signature::factory()->create();
+        event(new WaiverSigned($signature));
+
+        Event::assertDispatched(WaiverSigned::class, function ($event) use ($signature) {
+            return $event->signature->id === $signature->id;
+        });
+    }
+}

--- a/tests/Unit/Events/WaiverSignedTest.php
+++ b/tests/Unit/Events/WaiverSignedTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Tipoff\Waivers\Tests\Unit\Events;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
 use Tipoff\Waivers\Events\WaiverSigned;
 use Tipoff\Waivers\Models\Signature;
 use Tipoff\Waivers\Tests\TestCase;
-use Illuminate\Support\Facades\Event;
 
 class WaiverSignedTest extends TestCase
 {

--- a/tests/Unit/Listeners/CreateParticipantTest.php
+++ b/tests/Unit/Listeners/CreateParticipantTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace Tipoff\Waivers\Tests\Unit\Listeners;
 
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Tipoff\Waivers\Events\WaiverSigned;
 use Tipoff\Waivers\Models\Signature;
 use Tipoff\Waivers\Tests\TestCase;
-use Illuminate\Support\Facades\Event;
 
 class CreateParticipantTest extends TestCase
 {

--- a/tests/Unit/Listeners/CreateParticipantTest.php
+++ b/tests/Unit/Listeners/CreateParticipantTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tipoff\Waivers\Tests\Unit\Listeners;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+use Tipoff\Waivers\Events\WaiverSigned;
+use Tipoff\Waivers\Models\Signature;
+use Tipoff\Waivers\Tests\TestCase;
+use Illuminate\Support\Facades\Event;
+
+class CreateParticipantTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    /** @test */
+    public function participant_created()
+    {
+        Event::fake();
+
+        $signature = Signature::factory()->create();
+        event(new WaiverSigned($signature));
+
+        //Todo: Need to figure out a way to assert the creation of a participant entry
+
+        $this->assertTrue(Schema::hasTable('signatures'));
+        $this->assertDatabaseCount('signatures', 1);
+
+        //Todo: Need to figure out a way to assert the creation of a feedback entry
+    }
+}


### PR DESCRIPTION
Added `WaiverSigned` and the associated listeners

I made a test to properly check for the event firing, but will need to figure out ways to test the listeners, primarily `CreateParticipant` since it generates a signature, feedback, and participant entry. Only one of these models is contained within this package.

The code for the Waiver confirmation appears to have been commented out as of now, I can remove this if there is no plans to further develop that listener.